### PR TITLE
Fixed bug for optExecOptions when processing more than 1 file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Comming Soon!
 
 ## Release History
 
+- **(next version)**, Fixed bug that optExecOptions was passed only to first file in list
 - **v0.1.1**, *16 Dec 2013* Big Bang, moved codebase from original [`grunt-closure-tools` repo](https://github.com/closureplease/grunt-closure-tools).
 
 ## License

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -173,7 +173,7 @@ helpers.runCommands = function runCommands( commands, cb, optSilent, optExecOpti
   helpers.executeCommand( commandObj.cmd , function execCB( state, stderr, stdout ) {
     if ( state ) {
       if (!optSilent) helpers.log.info( 'Command complete for target: ' + commandObj.dest );
-    helpers.runCommands( commands, cb, optSilent);
+    helpers.runCommands( commands, cb, optSilent, optExecOptions);
     } else {
       if ( 'string' !== typeof(commandObj.dest)) {
         commandObj.dest = 'undefined';


### PR DESCRIPTION
optExecOptions wasn't passed to next calls for runCommands
Bug reported in grunt-closure-tools:
https://github.com/closureplease/grunt-closure-tools/issues/51
