### PR TITLE
Add speed optimization options to libCompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Comming Soon!
 
 ## Release History
 
+- **v0.1.3**, *20 Feb 2014* Added d32 and TieredCompilation optimization options to compiler java command
 - **v0.1.2**, *13 Jan 2014*
   - Fixed bug that optExecOptions was passed only to first file in list by [@stforek](https://github.com/stforek).
 - **v0.1.1**, *16 Dec 2013* Big Bang, moved codebase from original [`grunt-closure-tools` repo](https://github.com/closureplease/grunt-closure-tools).

--- a/lib/libCompiler.js
+++ b/lib/libCompiler.js
@@ -1,5 +1,4 @@
 
-
 var fs = require('fs'),
     path = require('path'),
     gruntMod = require('grunt'),
@@ -57,12 +56,10 @@ compiler.validateFile = function validateFile( fileObj ) {
 compiler.compileCommand = function compileCommand( options, fileObj ) {
 
   var cmd = 'java ' +
-    // adding compiling speed optimizations as found by Igor Minar
-    // http://than.pol.as/NfzB
-    // no, don't add it for now, it breaks travis-builds
-    // https://travis-ci.org/closureplease/grunt-closure-tools/builds/5625329
-    //' -client' +
-    //' -d32' +
+    // optional speed optimizations
+    // d32 as found by Igor Minar http://than.pol.as/NfzB
+    (options.d32 ? ' -client -d32 ' : '') +
+    (options.TieredCompilation ? ' -server -XX:+TieredCompilation ' : '') +
     ' -jar ' + options.compilerFile + ' ';
 
   //

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "task-closure-tools",
   "description": "Google Closure Library Tools, Compiler, DepsWriter, Builder.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/thanpolas/task-closure-tools",
   "author": {
     "name": "Thanasis Polychronakis",


### PR DESCRIPTION
2 new compiler options for optimizing Java VM:
- `d32: true` -> `java -client -d32`
- `TieredCompilation: true` -> `java -server -XX:+TieredCompilation`

Further to #2

I think this is all that's needed (apart from documenting). To my surprise, my tests so far show that d32 is faster on my machine than TieredCompilation, though this probably depends not only on the machine/environment, but also on the size/complication of the compilation. I'd suggest pushing this, and then getting other people to try out on a variety of machines. If there's a clear pattern, recommendations can then be made in the docs. As these are extra options, there should be no bc issues.
