### PR TITLE
Solve issues when compilerFile has spaces

### DIFF
--- a/lib/libCompiler.js
+++ b/lib/libCompiler.js
@@ -60,7 +60,7 @@ compiler.compileCommand = function compileCommand( options, fileObj ) {
     // d32 as found by Igor Minar http://than.pol.as/NfzB
     (options.d32 ? ' -client -d32 ' : '') +
     (options.TieredCompilation ? ' -server -XX:+TieredCompilation ' : '') +
-    ' -jar ' + options.compilerFile + ' ';
+    ' -jar "' + options.compilerFile + '" ';
 
   //
   // check for js files


### PR DESCRIPTION
Solve an issue that occurs when the given path to the compiler file has
spaces.

For example, if you set compilerFile = 'my path/compiler.jar', the
command
to be run on the shell would be:

jar my path/compiler.jar ...

...which is obviously incorrect.
