### PR TITLE
Fix silent compiler hang on empty src

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -68,15 +68,17 @@ helpers.makeParam = function makeParam(param, directive,
 /**
  * Will shell execute the given command
  *
- * @param {string} command.
+ * @param {string | Object} command.
  * @param {Function(boolean, string=)} done callback to call when done.
  * @param  {boolean=}   optSilent Suppress stdout messages.
  * @param {Object} optExecOptions plain object of options for exec function
  * @return {void}
  */
 helpers.executeCommand = function executeCommand( command, done, optSilent, optExecOptions ) {
-
-  if ( !optSilent ) helpers.log.info('Executing: '.blue + command);
+  if ( !optSilent ){
+    helpers.log.info('Executing: '.blue +
+      (command.type ? command.type + ' to ' + command.dest.cyan : command));
+  }
 
   function execCB(err, stdout, stderr) {
     if ( err ) {
@@ -85,9 +87,16 @@ helpers.executeCommand = function executeCommand( command, done, optSilent, optE
       return;
     }
 
-    if ( !optSilent ) helpers.log.info(stdout || stderr);
+    if ( !optSilent && (stdout || stderr)) helpers.log.info(stdout || stderr);
     done(true, stdout);
   }
+  // Check if we have an epty write command.
+  if(command.type === 'empty'){
+    grunt.file.write(command.dest, '');
+    execCB(false, '');
+    return;
+  }
+  // Otherwise just execute the command string.
   if (optExecOptions) {
     exec(command, optExecOptions, execCB);
   } else {

--- a/lib/libCompiler.js
+++ b/lib/libCompiler.js
@@ -50,6 +50,7 @@ compiler.validateFile = function validateFile( fileObj ) {
  * Prepare and compile the compiler command we will execute
  *
  * @param {Object} options The options.
+ * @param {Object} fileObj The file object to be compiled.
  * @return {string|boolean} boolean false if we failed,
  *   command string if all ok.
  */
@@ -67,7 +68,7 @@ compiler.compileCommand = function compileCommand( options, fileObj ) {
   // check for js files
   //
   var src = gruntMod.file.expand({nonull: true}, fileObj.src || []);
-  if (0 < src.length) {
+  if (src.length > 0) {
     cmd += helpers.makeParam(src, '--js');
   }
 
@@ -79,6 +80,16 @@ compiler.compileCommand = function compileCommand( options, fileObj ) {
     dest = gruntMod.template.process(dest);
   }
 
+  // Check if there are any files to write out. If not, make up an empty command.
+  if (src.length === 0) {
+    helpers.log.warn('Either no src files selected or all filtered out. Writing empty file to ' + dest.cyan);
+    // Command sub object for internal representation of commands that aren't executed in the shell
+    cmd = {
+      type: 'empty',
+      dest: dest
+    };
+    return cmd;
+  }
   // check if output file is defined
   if (dest && dest.length) {
 

--- a/test/compiler.test.js
+++ b/test/compiler.test.js
@@ -1,0 +1,48 @@
+var grunt = require('grunt');
+var sinon = require('sinon');
+var compiler = require('../').compiler;
+var configs = require('./configs.fix');
+var expectations = require('./expected/expectations.compiler');
+
+
+/*
+  ======== A Handy Little Nodeunit Reference ========
+  https://github.com/caolan/nodeunit
+
+  Test methods:
+    test.expect(numAssertions)
+    test.done()
+  Test assertions:
+    test.ok(value, [message])
+    test.equal(actual, expected, [message])
+    test.notEqual(actual, expected, [message])
+    test.deepEqual(actual, expected, [message])
+    test.notDeepEqual(actual, expected, [message])
+    test.strictEqual(actual, expected, [message])
+    test.notStrictEqual(actual, expected, [message])
+    test.throws(block, [error], [message])
+    test.doesNotThrow(block, [error], [message])
+    test.ifError(value)
+*/
+
+var stubFileWrite;
+
+exports.compiler = {
+  setUp: function(done) {
+    stubFileWrite = sinon.stub( grunt.file, 'write' );
+    stubFileWrite.returns( true );
+    done();
+  },
+  tearDown: function(done) {
+    stubFileWrite.restore();
+    done();
+  },
+
+  // Testing if the correct command is compiled when there are no source files given.
+  emptySrc: function( test ) {
+    test.expect(1);
+    var actual = compiler.compileCommand( {}, configs.compiler.empty );
+    test.deepEqual(actual, expectations.empty, 'Should be equal');
+    test.done();
+  }
+};

--- a/test/configs.fix.js
+++ b/test/configs.fix.js
@@ -1,12 +1,15 @@
 /*jshint camelcase:false */
 var configs = {
-  builder: {}
+  builder: {},
+  compiler: {},
+  helpers: {}
 };
 
+// Known test locations for compiler and builder files
 var CLOSURE_COMPILER = 'path/to/compiler.jar',
     CLOSURE_BUILDER = 'path/to/builder.py';
 
-
+// Builder test case with compiler options
 configs.builder.withCompileOpts = {
   builder: CLOSURE_BUILDER,
   inputs: 'path/to/inputs',
@@ -21,8 +24,22 @@ configs.builder.withCompileOpts = {
 
   }
 };
+
+// Builder test case with file object
 configs.builder.withCompileFileObj = {
   src: ['/path/to/source1', 'path/source2']
+};
+
+// Compiler test case that doesn't have any source files.
+configs.compiler.empty = {
+  dest: 'test/dest.js',
+  src: []
+};
+
+// A generic empty test case for trying out helpers.execute.
+configs.helpers.empty = {
+  type: 'empty',
+  dest: configs.compiler.empty.dest
 };
 
 module.exports = configs;

--- a/test/expected/expectations.compiler.js
+++ b/test/expected/expectations.compiler.js
@@ -1,0 +1,10 @@
+var configs = require('../configs.fix');
+var expectations = {};
+
+// The expected empty command from a compiled command with no src files.
+expectations.empty = {
+	type: 'empty',
+	dest: configs.compiler.empty.dest
+};
+
+module.exports = expectations;

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,45 @@
+var grunt = require('grunt');
+var sinon = require('sinon');
+var helpers = require('../').helpers;
+var configs = require('./configs.fix');
+
+/*
+  ======== A Handy Little Nodeunit Reference ========
+  https://github.com/caolan/nodeunit
+
+  Test methods:
+    test.expect(numAssertions)
+    test.done()
+  Test assertions:
+    test.ok(value, [message])
+    test.equal(actual, expected, [message])
+    test.notEqual(actual, expected, [message])
+    test.deepEqual(actual, expected, [message])
+    test.notDeepEqual(actual, expected, [message])
+    test.strictEqual(actual, expected, [message])
+    test.notStrictEqual(actual, expected, [message])
+    test.throws(block, [error], [message])
+    test.doesNotThrow(block, [error], [message])
+    test.ifError(value)
+*/
+
+var stubFileWrite;
+
+exports.helper = {
+  setUp: function(done) {
+    stubFileWrite = sinon.stub( grunt.file, 'write' );
+    stubFileWrite.returns( true );
+    done();
+  },
+  tearDown: function(done) {
+    stubFileWrite.restore();
+    done();
+  },
+  // Testing if an empty file is written to dest when the empty command is used
+  emptySrc: function( test ) {
+    test.expect(1);
+    helpers.executeCommand(configs.helpers.empty, function(){});
+    test.equal(stubFileWrite.calledWith(configs.helpers.empty.dest, ''), true);
+    test.done();
+  }
+};


### PR DESCRIPTION
This PR addresses https://github.com/thanpolas/grunt-closure-tools/issues/67 which was initially incorrectly reported in that repo.
#### Summary of issue

When there are no src files provided to `libCompiler.js:compiler.compileCommand` the generated command breaks Closure Compiler with a silent hang.
#### Expected behavior

If no src files are provided, a blank file is created at the provided destination.
#### Work in this PR
- Fixes silent compiler hang when `src` files are empty by not invoking Closure Compiler in this case.
- Implements default empty `src` behavior: blank file written to `dest`.
- Adds unit tests for empty `src` activity.

To keep the paradigm and separation of "build commands in `libCompiler.js`, execute commands in `helpers.js`" that was already going on, the following modifications were made:
- `libCompiler.js:compiler.compileCommand` now detects empty src, and generates a new type of command -- an object instead of a string -- that can be used for new, non-shell-script command types going forward.
- `helpers.js:helpers.executeCommand` now handles the new command types, and has a case for the new empty command.
#### Notes

New functionality is exclusively in `lib/helpers.js` and `lib/libCompiler.js`. The rest is just tests etc. Did not see a `CHANGELOG.md` file as mentioned in `CONTRIBUTING` but happy to add to it if I just missed it.

![](http://38.media.tumblr.com/tumblr_lrd6l5OI1D1qa0v77o1_500.gif)
