### PR TITLE
allow namespaces in options or configs

### DIFF
--- a/lib/libBuilder.js
+++ b/lib/libBuilder.js
@@ -46,13 +46,13 @@ builder.validate = function ( options )
   // ---
   // Check for inputs or paths
   // ---
-  var inputs = options.inputs || [];
-  var namespaces = options.namespaces;
-  if ((!inputs || 0 === inputs.length) && !namespaces) {
-    cHelpers.log.error('inputs'.red + ' or ' + 'namespaces'.red +
-      ' properties are required');
-    return false;
-  }
+//  var inputs = options.inputs || [];
+//  var namespaces = options.namespaces;
+//  if ((!inputs || 0 === inputs.length) && !namespaces) {
+//    cHelpers.log.error('inputs'.red + ' or ' + 'namespaces'.red +
+//      ' properties are required');
+//    return false;
+//  }
 
   return true;
 };
@@ -104,9 +104,16 @@ builder.createCommand = function createCommand ( options, fileObj ) {
     cmd += cHelpers.makeParam( inputs, '-i', false, true);
   }
   // check for namespaces
-  if (options.namespaces && options.namespaces.length) {
-    cmd += cHelpers.makeParam( options.namespaces, '-n' );
+  var namespaces = fileObj.namespaces?fileObj.namespaces:options.namespaces;
+  if (namespaces && namespaces.length ) {
+    cmd += cHelpers.makeParam( namespaces, '-n' );
   }
+  
+  if (!inputs && !namespaces ){
+      cHelpers.log.error('inputs'.red + ' or ' + 'namespaces'.red + ' properties are required');
+      return false;
+  }
+  
   // append root
   var allRoots = gruntMod.file.expand( fileObj.src );
   cmd += cHelpers.makeParam( allRoots, '--root=', true, true);
@@ -200,3 +207,4 @@ builder.createCommand = function createCommand ( options, fileObj ) {
 
 
 module.exports = builder;
+


### PR DESCRIPTION
Just a small modification to use different namespaces per config. Very useful for multiple subprojects per project.

I have comented the validate section for options.namespaces || options.inputs, 
I would remove it but maye you prefer validate everything here