### PR TITLE
Allow override java w/ environment varible JAVACMD

### DIFF
--- a/lib/libCompiler.js
+++ b/lib/libCompiler.js
@@ -56,7 +56,8 @@ compiler.validateFile = function validateFile( fileObj ) {
  */
 compiler.compileCommand = function compileCommand( options, fileObj ) {
 
-  var cmd = 'java ' +
+  var javaCmd = process.env.JAVACMD || 'java';
+  var cmd = javaCmd + ' ' +
     (options.javaFlags ? options.javaFlags.join(' ') : '') +
     // optional speed optimizations
     // d32 as found by Igor Minar http://than.pol.as/NfzB


### PR DESCRIPTION
This is useful on MacOSX if you have multiple
java versions.  You can symlink java17 to your
java 1.7 VM and call
JAVACMD=java17 grunt...